### PR TITLE
Use label option if provided

### DIFF
--- a/app/views/fields/hyperlink/_show.html.erb
+++ b/app/views/fields/hyperlink/_show.html.erb
@@ -17,5 +17,5 @@ By default, the attribute is rendered as a hyperlink to the data with the entire
 %>
 
 <% if field.present? %>
-  <%= link_to field.data, field.href, target: '_blank', rel: 'noopener noreferrer' %>
+  <%= link_to field.to_s, field.href, target: '_blank', rel: 'noopener noreferrer' %>
 <% end %>


### PR DESCRIPTION
`to_s` defaults to `data` when label option is not provided.
This PR should not change behavior of existing application when label option is not used